### PR TITLE
Create enoceanmqtt.conf

### DIFF
--- a/enoceanmqtt.conf
+++ b/enoceanmqtt.conf
@@ -1,0 +1,19 @@
+# the general section defines parameter for the mqtt broker and the enocean interface
+[CONFIG]
+enocean_port    = /dev/enocean
+log_packets     = 1
+
+mqtt_host       = localhost
+mqtt_port       = 1883
+# the prefix is used for the mqtt value names; this is extended by the sensor name
+mqtt_prefix     = enocean/
+# optionally also set mqtt_user and mqtt_pwd
+
+
+# all other sections define the sensors to monitor
+
+[contact]
+address = 0x018070cb
+rorg    = 0xd5   
+func    = 0x00
+type = 0x01


### PR DESCRIPTION
Fichier de config - premier contact 70cb inséré, manque le deuxième